### PR TITLE
Updated artifactory requires Java8

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Installs JFrog's Artifactory
 
 # Requirements
-* Java 7 (java cookbook)
+* Java 8 (java cookbook)
 * ark cookbook
 
 # Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
-default['artifactory']['zip_url'] = 'http://dl.bintray.com/content/jfrog/artifactory/artifactory-3.8.0'
-default['artifactory']['zip_checksum'] = '8f5e2b46bb5db96afd2185cd74edd5ec87a5ee5e7d7d3ec86500e44730917c69'
+default['artifactory']['zip_url'] = 'http://dl.bintray.com/content/jfrog/artifactory/jfrog-artifactory-oss-4.6.1.zip'
+default['artifactory']['zip_checksum'] = 'a4cf127698a4fc455e2a186bb95cb607f5cb7681cfb4d693dd2f5aee28666ce0'
 default['artifactory']['home'] = '/var/lib/artifactory'
 default['artifactory']['log_dir'] = '/var/log/artifactory'
 default['artifactory']['catalina_base'] = ::File.join(artifactory['home'], 'tomcat')

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@agileorbit.com'
 license          'Apache V2'
 description      'Installs/Configures artifactory'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.2'
+version          '0.3.3'
 
 recipe 'artifactory::default', 'Installs Artifactory.'
 recipe 'artifactory::apache-proxy', 'Setup Apache reverse proxy in front of Artifactory.'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,7 +8,7 @@
 #
 
 if node['artifactory']['install_java']
-  node.set['java']['jdk_version'] = 7
+  node.set['java']['jdk_version'] = 8
   include_recipe 'java'
 end
 


### PR DESCRIPTION
Newer versions of Artifactory requires Java version 8. 
There is no down site to run Artifactory version 8. This cookbook tries downgrade Java to version 7 if an attribute was not set. This patch help to correct this issue. 
